### PR TITLE
Allow passing options to serializer for decoding based on the opcode (:text or :binary)

### DIFF
--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -228,7 +228,7 @@ defmodule Phoenix.Channels.GenSocketClient do
     do: GenServer.cast(socket, {:notify_disconnected, reason})
 
   @doc "Forwards a received message to the socket process."
-  @spec notify_message(GenServer.server(), binary) :: :ok
+  @spec notify_message(GenServer.server(), {:text | :binary, binary}) :: :ok
   def notify_message(socket, message), do: GenServer.cast(socket, {:notify_message, message})
 
   # -------------------------------------------------------------------
@@ -271,8 +271,8 @@ defmodule Phoenix.Channels.GenSocketClient do
     invoke_callback(reinit(state), :handle_disconnected, [reason])
   end
 
-  def handle_cast({:notify_message, encoded_message}, state) do
-    decoded_message = state.serializer.decode_message(encoded_message)
+  def handle_cast({:notify_message, {opcode, encoded_message}}, state) do
+    decoded_message = state.serializer.decode_message(encoded_message, opcode: opcode)
     handle_message(decoded_message, state)
   end
 

--- a/lib/gen_socket_client/serializer.ex
+++ b/lib/gen_socket_client/serializer.ex
@@ -6,7 +6,8 @@ defmodule Phoenix.Channels.GenSocketClient.Serializer do
   alias Phoenix.Channels.GenSocketClient
 
   @doc "Invoked to decode the raw message."
-  @callback decode_message(GenSocketClient.encoded_message()) :: GenSocketClient.message()
+  @callback decode_message(GenSocketClient.encoded_message(), Keyword.t()) ::
+              GenSocketClient.message()
 
   @doc "Invoked to encode a socket message."
   @callback encode_message(GenSocketClient.message()) ::
@@ -22,7 +23,7 @@ defmodule Phoenix.Channels.GenSocketClient.Serializer.Json do
   # -------------------------------------------------------------------
 
   @doc false
-  def decode_message(encoded_message), do: Jason.decode!(encoded_message)
+  def decode_message(encoded_message, _opts), do: Jason.decode!(encoded_message)
 
   @doc false
   def encode_message(message) do
@@ -42,7 +43,7 @@ defmodule Phoenix.Channels.GenSocketClient.Serializer.GzipJson do
   # -------------------------------------------------------------------
 
   @doc false
-  def decode_message(encoded_message) do
+  def decode_message(encoded_message, _opts) do
     encoded_message
     |> :zlib.gunzip()
     |> Jason.decode!()

--- a/lib/gen_socket_client/transport/web_socket_client.ex
+++ b/lib/gen_socket_client/transport/web_socket_client.ex
@@ -64,7 +64,7 @@ defmodule Phoenix.Channels.GenSocketClient.Transport.WebSocketClient do
   def websocket_handle({:pong, _message}, _req, state), do: {:ok, state}
 
   def websocket_handle({type, message}, _req, state) when type in [:text, :binary] do
-    GenSocketClient.notify_message(state.socket, message)
+    GenSocketClient.notify_message(state.socket, {type, message})
     {:ok, state}
   end
 


### PR DESCRIPTION
Currently, since the opcode is not being passed to the serializer, it is not possible to know if it is text or binary, and this may be helpful to know whether to decode/encode a JSON-text or a binary – for example, be able to do something like https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/socket/serializers/v2_json_serializer.ex#L102-L108