### PR TITLE
Add socket_opts to websocket client options

### DIFF
--- a/lib/gen_socket_client/transport/web_socket_client.ex
+++ b/lib/gen_socket_client/transport/web_socket_client.ex
@@ -15,7 +15,7 @@ defmodule Phoenix.Channels.GenSocketClient.Transport.WebSocketClient do
   """
   @behaviour Phoenix.Channels.GenSocketClient.Transport
   @behaviour :websocket_client
-  @websocket_client_opts [:extra_headers, :ssl_verify]
+  @websocket_client_opts [:extra_headers, :ssl_verify, :socket_opts]
 
   require Logger
   require Record


### PR DESCRIPTION
Allow passing also socket_opts to the underlying websocket client. This
is required to pass additional ssl options to the socket, which might be
useful in some usecases (e.g. :customize_hostname_check to support
wildcard certificates)
