### PR TITLE
Generate string message refs instead of integers

### DIFF
--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -403,8 +403,10 @@ defmodule Phoenix.Channels.GenSocketClient do
   defp transport(state), do: Map.take(state, [:transport_mod, :transport_pid, :serializer])
 
   defp next_ref(event, topic) do
-    ref = Process.get({__MODULE__, :ref}, 0) + 1
-    Process.put({__MODULE__, :ref}, ref)
+    ref_counter = Process.get({__MODULE__, :ref}, 0) + 1
+    Process.put({__MODULE__, :ref}, ref_counter)
+
+    ref = to_string(ref_counter)
 
     join_ref = if event == "phx_join", do: ref, else: join_ref(topic)
 

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -79,6 +79,12 @@ defmodule Phoenix.Channels.GenSocketClientTest do
     assert_receive {TestSite.Channel, {:terminate, {:shutdown, :left}}}
   end
 
+  test "push references are strings" do
+    conn = join_channel()
+    {:ok, ref} = TestSocket.push(conn.socket, "channel:1", "event")
+    assert is_binary(ref)
+  end
+
   test "push references are monotonically increasing on the same channel" do
     conn = join_channel()
     {:ok, ref1} = TestSocket.push(conn.socket, "channel:1", "event1")


### PR DESCRIPTION
The phoenix documentation says that message refs should be "unique strings".

Fixes https://github.com/J0/phoenix_gen_socket_client/issues/65