### PR TITLE
Fix disconnect callback for latest versions of `websocket_client`

### DIFF
--- a/lib/gen_socket_client/transport/web_socket_client.ex
+++ b/lib/gen_socket_client/transport/web_socket_client.ex
@@ -75,6 +75,17 @@ defmodule Phoenix.Channels.GenSocketClient.Transport.WebSocketClient do
 
   @doc false
   def websocket_info({:send_frame, frame}, _req, state), do: {:reply, frame, state}
+
+  def websocket_info({:tcp_closed, _pid}, _req, state) do
+    GenSocketClient.notify_disconnected(state.socket, {:remote, :closed})
+    {:close, "", state}
+  end
+
+  def websocket_info({:ssl_closed, _ssl_socket}, _req, state) do
+    GenSocketClient.notify_disconnected(state.socket, {:remote, :closed})
+    {:close, "", state}
+  end
+
   def websocket_info(_message, _req, state), do: {:ok, state}
 
   @doc false


### PR DESCRIPTION
In `websocket_client` versions 1.4.0 and later, the `ondisconnect/2` callback is only triggered in the `connected` and `handshaking` states. This causes the `tcp_closed` message to go to the `websocket_info/3` callback instead of invoking the `ondisconnect/2` callback.  See [https://github.com/sanmiguel/websocket_client/pull/78](https://github.com/sanmiguel/websocket_client/pull/78) for more info.

As it is now, `phoenix_gen_socket_client` silently ignores unknown `websocket_info/3` messages.  The Phoenix Channel client becomes disconnected without invoking any of its callbacks.

This commit updates the built-in transport to maintain consistent behavior through the latest versions of `websocket_client`.